### PR TITLE
Change scope handling logic

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1508,7 +1508,7 @@ _It can be asynchronous._
 
 
 ## `checkScopeAuthority`
-`checkScopeAuthority(ctx?: Context, name?: string, scope?: any)`
+`checkScopeAuthority(ctx?: Context, name: string, operation: string, scope: any)`
 
 You should implement it if you want to check the authorization of scopes.
 
@@ -1518,10 +1518,9 @@ _It can be asynchronous._
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | `ctx` | `Context` | Moleculer `Context` instance. It can be `null`. |
-| `name` | `String?` | Name of the scope. |
-| `scope` | `any?` | Scope definition. |
-
-_If `name` and `scope` are `null`, it means that you should check the authority of default scope disabling._
+| `name` | `String` | Name of the scope. |
+| `operation` | `String` | Type of operation. Available values: `add`, `remove`. |
+| `scope` | `any` | Scope definition. |
 
 # Scopes
 The scopes allow you to add constraints for all query methods, like `find`, `list` or `count`. You can use them with soft-delete feature if you want to list only non-deleted entities.
@@ -1922,17 +1921,15 @@ module.exports = {
     methods: {
         /**
          * Check the scope authority. Should be implemented in the service.
-         * If `name and `scope` are null, it means you should check the permissions
-         * when somebody wants to turn off the default scopes (e.g. list
-         * deleted records, as well).
          *
          * @param {Context} ctx
-         * @param {String?} name
-         * @param {Object?} scope
+         * @param {String} name
+         * @param {String} operation
+         * @param {Object} scope
          */        
-        async checkScopeAuthority(ctx, name, scope) {
+        async checkScopeAuthority(ctx, name, operation, scope) {
             // We enable default scope disabling only for administrators.
-            if (scope == null) {
+            if (operation == "remove") {
                 return ctx.meta.user.roles.includes("admin");
             }
 

--- a/src/methods.js
+++ b/src/methods.js
@@ -180,7 +180,7 @@ module.exports = function (mixinOpts) {
 						if (!scope) continue;
 
 						if (_.isFunction(scope)) q = await scope.call(this, q, ctx, params);
-						else q = _.defaultsDeep(q, scope);
+						else q = _.merge(q, scope);
 					}
 					params.query = q;
 
@@ -239,7 +239,11 @@ module.exports = function (mixinOpts) {
 				p.populate = p.populate.replace(/,/g, " ").split(" ");
 			if (typeof p.searchFields === "string")
 				p.searchFields = p.searchFields.replace(/,/g, " ").split(" ");
-			if (typeof p.scope === "string") p.scope = p.scope.replace(/,/g, " ").split(" ");
+			if (typeof p.scope === "string") {
+				if (p.scope === "true") p.scope = true;
+				else if (p.scope === "false") p.scope = false;
+				else p.scope = p.scope.replace(/,/g, " ").split(" ");
+			}
 
 			if (opts && opts.removeLimit) {
 				if (p.limit) delete p.limit;

--- a/src/methods.js
+++ b/src/methods.js
@@ -209,7 +209,7 @@ module.exports = function (mixinOpts) {
 				const scope = this.settings.scopes[scopeName];
 				if (!scope) continue;
 
-				const has = await this.checkScopeAuthority(ctx, scopeName, scope, operation);
+				const has = await this.checkScopeAuthority(ctx, scopeName, operation, scope);
 				if ((operation == "add" && has) || (operation == "remove" && !has)) {
 					res.push(scopeName);
 				}

--- a/src/validation.js
+++ b/src/validation.js
@@ -152,11 +152,11 @@ module.exports = function (mixinOpts) {
 		 * Check the scope authority. Should be implemented in the service.
 		 *
 		 * @param {Context} ctx
-		 * @param {String?} name
-		 * @param {Object?} scope
-		 * @param {Boolean} operation Values: "add", "remove"
+		 * @param {String} name
+		 * @param {String} operation Values: "add", "remove"
+		 * @param {Object} scope
 		 */
-		async checkScopeAuthority(/*ctx, name, scope, operation*/) {
+		async checkScopeAuthority(/*ctx, name, operation, scope*/) {
 			return true;
 		},
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -157,8 +157,9 @@ module.exports = function (mixinOpts) {
 		 * @param {Context} ctx
 		 * @param {String?} name
 		 * @param {Object?} scope
+		 * @param {Boolean} operation Values: "add", "remove"
 		 */
-		async checkScopeAuthority(/*ctx, name, scope*/) {
+		async checkScopeAuthority(/*ctx, name, scope, operation*/) {
 			return true;
 		},
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -150,9 +150,6 @@ module.exports = function (mixinOpts) {
 
 		/**
 		 * Check the scope authority. Should be implemented in the service.
-		 * If `name and `scope` are null, it means you should check the permissions
-		 * when somebody wants turning off the default scopes (e.g. list
-		 * deleted records, as well).
 		 *
 		 * @param {Context} ctx
 		 * @param {String?} name

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -115,7 +115,7 @@ if (process.env.GITHUB_ACTIONS_CI) {
 } else {
 	// Local development tests
 	Adapters = [
-		/*{
+		{
 			type: "NeDB"
 		}
 		/*{ type: "MongoDB", options: { dbName: "db_int_test" } },
@@ -195,7 +195,7 @@ if (process.env.GITHUB_ACTIONS_CI) {
 					}
 				}
 			}
-		},*/
+		},
 		{
 			name: "Knex-MSSQL",
 			type: "Knex",
@@ -212,7 +212,7 @@ if (process.env.GITHUB_ACTIONS_CI) {
 					}
 				}
 			}
-		}
+		}*/
 	];
 }
 

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -5,11 +5,6 @@ const ApiGateway = require("moleculer-web");
 const axios = require("axios");
 const DbService = require("../..").Service;
 
-const Fakerator = require("fakerator");
-const fakerator = new Fakerator();
-const fs = require("fs");
-const { Stream, Readable } = require("stream");
-
 module.exports = (getAdapter, adapterType) => {
 	describe("Test REST API with populates", () => {
 		const env = createEnvironment(getAdapter, adapterType);

--- a/test/integration/scopes.test.js
+++ b/test/integration/scopes.test.js
@@ -153,6 +153,15 @@ module.exports = (getAdapter, adapterType) => {
 			it("should filtered by desired scope", async () => {
 				const params = { scope: "young" };
 				const rows = await svc.findEntities(ctx, params);
+				expect(rows).toEqual(expect.arrayContaining([docs.johnDoe, docs.kevinJames]));
+
+				const count = await svc.countEntities(ctx, params);
+				expect(count).toEqual(2);
+			});
+
+			it("should filtered by desired scope without default scope", async () => {
+				const params = { scope: ["young", "-onlyActive"] };
+				const rows = await svc.findEntities(ctx, params);
 				expect(rows).toEqual(
 					expect.arrayContaining([docs.johnDoe, docs.janeDoe, docs.kevinJames])
 				);

--- a/test/unit/scoping.spec.js
+++ b/test/unit/scoping.spec.js
@@ -171,22 +171,12 @@ describe("Test scoping", () => {
 			expect(res).toEqual({ query: { status: true, tenantId: 1001 } });
 
 			expect(checkScopeAuthority).toBeCalledTimes(2);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"onlyActive",
-				{
-					status: true
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", "add", {
+				status: true
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should add desired scope", async () => {
@@ -200,30 +190,15 @@ describe("Test scoping", () => {
 			});
 
 			expect(checkScopeAuthority).toBeCalledTimes(3);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"onlyActive",
-				{
-					status: true
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"public",
-				{
-					visibility: "public"
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", "add", {
+				status: true
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", "add", {
+				visibility: "public"
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should add desired scope and remove default scope", async () => {
@@ -240,27 +215,17 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"onlyActive",
+				"remove",
 				{
 					status: true
-				},
-				"remove"
+				}
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"public",
-				{
-					visibility: "public"
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", "add", {
+				visibility: "public"
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should add nothing", async () => {
@@ -273,19 +238,14 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"onlyActive",
+				"remove",
 				{
 					status: true
-				},
-				"remove"
+				}
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"remove"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "remove", {
+				tenantId: 1001
+			});
 		});
 
 		it("should add the custom scope", async () => {
@@ -308,25 +268,15 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"custom",
-				scopeFn,
-				"add"
+				"add",
+				scopeFn
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"onlyActive",
-				{
-					status: true
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", "add", {
+				status: true
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should add multiple scope", async () => {
@@ -343,33 +293,18 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"custom",
-				scopeFn,
-				"add"
+				"add",
+				scopeFn
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"public",
-				{
-					visibility: "public"
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"onlyActive",
-				{
-					status: true
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", "add", {
+				visibility: "public"
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", "add", {
+				status: true
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should not add desired scope if not permission", async () => {
@@ -381,30 +316,15 @@ describe("Test scoping", () => {
 			expect(res).toEqual({ scope: "public" });
 
 			expect(checkScopeAuthority).toBeCalledTimes(3);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"public",
-				{
-					visibility: "public"
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"onlyActive",
-				{
-					status: true
-				},
-				"add"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", "add", {
+				visibility: "public"
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", "add", {
+				status: true
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "add", {
+				tenantId: 1001
+			});
 		});
 
 		it("should not disable the tenant scope", async () => {
@@ -418,19 +338,14 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"onlyActive",
+				"remove",
 				{
 					status: true
-				},
-				"remove"
+				}
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"remove"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "remove", {
+				tenantId: 1001
+			});
 		});
 
 		it("should not disable the tenant scope", async () => {
@@ -447,27 +362,17 @@ describe("Test scoping", () => {
 			expect(checkScopeAuthority).toBeCalledWith(
 				expect.any(Context),
 				"onlyActive",
+				"remove",
 				{
 					status: true
-				},
-				"remove"
+				}
 			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"tenant",
-				{
-					tenantId: 1001
-				},
-				"remove"
-			);
-			expect(checkScopeAuthority).toBeCalledWith(
-				expect.any(Context),
-				"public",
-				{
-					visibility: "public"
-				},
-				"add"
-			);
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "tenant", "remove", {
+				tenantId: 1001
+			});
+			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", "add", {
+				visibility: "public"
+			});
 		});
 	});
 

--- a/test/unit/scoping.spec.js
+++ b/test/unit/scoping.spec.js
@@ -130,7 +130,7 @@ describe("Test scoping", () => {
 		});
 
 		let checkScopeAuthorityReturnValue = () => true;
-		const checkScopeAuthority = jest.fn(async (ctx, name, scope, operation) =>
+		const checkScopeAuthority = jest.fn(async (ctx, name, operation, scope) =>
 			checkScopeAuthorityReturnValue(name, scope, operation)
 		);
 		const svc = broker.createService({

--- a/test/unit/scoping.spec.js
+++ b/test/unit/scoping.spec.js
@@ -19,13 +19,16 @@ describe("Test scoping", () => {
 					onlyActive: {
 						status: true
 					},
+					tenant: {
+						tenantId: 1001
+					},
 					public: {
 						visibility: "public"
 					},
 					custom: scopeFn
 				},
 
-				defaultScopes: ["onlyActive"]
+				defaultScopes: ["tenant", "onlyActive"]
 			}
 		});
 
@@ -38,21 +41,37 @@ describe("Test scoping", () => {
 			const params = {};
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { status: true } });
+			expect(res).toEqual({ query: { tenantId: 1001, status: true } });
 		});
 
-		it("should add default scope", async () => {
-			const params = { scope: true };
-
-			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { status: true }, scope: true });
-		});
-
-		it("should add desired scope", async () => {
+		it("should add desired scope besides default scopes", async () => {
 			const params = { scope: "public" };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { visibility: "public" }, scope: "public" });
+			expect(res).toEqual({
+				query: { tenantId: 1001, status: true, visibility: "public" },
+				scope: "public"
+			});
+		});
+
+		it("should remove a default scope", async () => {
+			const params = { scope: "-onlyActive" };
+
+			const res = await svc._applyScopes(params, ctx);
+			expect(res).toEqual({
+				query: { tenantId: 1001 },
+				scope: "-onlyActive"
+			});
+		});
+
+		it("should remove a default scope abd add a desired scope", async () => {
+			const params = { scope: ["public", "-onlyActive"] };
+
+			const res = await svc._applyScopes(params, ctx);
+			expect(res).toEqual({
+				query: { tenantId: 1001, visibility: "public" },
+				scope: ["public", "-onlyActive"]
+			});
 		});
 
 		it("should add nothing", async () => {
@@ -66,11 +85,14 @@ describe("Test scoping", () => {
 			const params = { scope: "custom" };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { a: 5, b: "Yes" }, scope: "custom" });
+			expect(res).toEqual({
+				query: { status: true, tenantId: 1001, a: 5, b: "Yes" },
+				scope: "custom"
+			});
 
 			expect(scopeFn).toBeCalledTimes(1);
-			expect(scopeFn).toBeCalledWith({ a: 5, b: "Yes" }, ctx, {
-				query: { a: 5, b: "Yes" },
+			expect(scopeFn).toBeCalledWith({ status: true, tenantId: 1001, a: 5, b: "Yes" }, ctx, {
+				query: { status: true, tenantId: 1001, a: 5, b: "Yes" },
 				scope: "custom"
 			});
 		});
@@ -80,7 +102,7 @@ describe("Test scoping", () => {
 
 			const res = await svc._applyScopes(params, ctx);
 			expect(res).toEqual({
-				query: { a: 5, b: "Yes", visibility: "public" },
+				query: { status: true, tenantId: 1001, a: 5, b: "Yes", visibility: "public" },
 				scope: ["custom", "notExist", "public"]
 			});
 		});
@@ -95,8 +117,8 @@ describe("Test scoping", () => {
 		});
 
 		let checkScopeAuthorityReturnValue = () => true;
-		const checkScopeAuthority = jest.fn(async (ctx, name, scope) =>
-			checkScopeAuthorityReturnValue(name, scope)
+		const checkScopeAuthority = jest.fn(async (ctx, name, scope, operation) =>
+			checkScopeAuthorityReturnValue(name, scope, operation)
 		);
 		const svc = broker.createService({
 			name: "posts",
@@ -106,13 +128,16 @@ describe("Test scoping", () => {
 					onlyActive: {
 						status: true
 					},
+					tenant: {
+						tenantId: 1001
+					},
 					public: {
 						visibility: "public"
 					},
 					custom: scopeFn
 				},
 
-				defaultScopes: ["onlyActive"]
+				defaultScopes: ["tenant", "onlyActive"]
 			},
 
 			methods: {
@@ -130,12 +155,25 @@ describe("Test scoping", () => {
 			const params = {};
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { status: true } });
+			expect(res).toEqual({ query: { status: true, tenantId: 1001 } });
 
-			expect(checkScopeAuthority).toBeCalledTimes(1);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", {
-				status: true
-			});
+			expect(checkScopeAuthority).toBeCalledTimes(2);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
 		});
 
 		it("should add desired scope", async () => {
@@ -143,12 +181,73 @@ describe("Test scoping", () => {
 			const params = { scope: "public" };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { visibility: "public" }, scope: "public" });
-
-			expect(checkScopeAuthority).toBeCalledTimes(1);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", {
-				visibility: "public"
+			expect(res).toEqual({
+				query: { tenantId: 1001, status: true, visibility: "public" },
+				scope: "public"
 			});
+
+			expect(checkScopeAuthority).toBeCalledTimes(3);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"public",
+				{
+					visibility: "public"
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
+		});
+
+		it("should add desired scope and remove default scope", async () => {
+			checkScopeAuthority.mockClear();
+			const params = { scope: ["public", "-onlyActive"] };
+
+			const res = await svc._applyScopes(params, ctx);
+			expect(res).toEqual({
+				query: { tenantId: 1001, visibility: "public" },
+				scope: ["public", "-onlyActive"]
+			});
+
+			expect(checkScopeAuthority).toBeCalledTimes(3);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"remove"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"public",
+				{
+					visibility: "public"
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
 		});
 
 		it("should add nothing", async () => {
@@ -157,8 +256,23 @@ describe("Test scoping", () => {
 
 			const res = await svc._applyScopes(params, ctx);
 			expect(res).toEqual({ scope: false });
-			expect(checkScopeAuthority).toBeCalledTimes(1);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), null, null);
+			expect(checkScopeAuthority).toBeCalledTimes(2);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"remove"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"remove"
+			);
 		});
 
 		it("should add the custom scope", async () => {
@@ -166,16 +280,40 @@ describe("Test scoping", () => {
 			const params = { scope: "custom" };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { a: 5, b: "Yes" }, scope: "custom" });
-
-			expect(scopeFn).toBeCalledTimes(1);
-			expect(scopeFn).toBeCalledWith({ a: 5, b: "Yes" }, ctx, {
-				query: { a: 5, b: "Yes" },
+			expect(res).toEqual({
+				query: { tenantId: 1001, status: true, a: 5, b: "Yes" },
 				scope: "custom"
 			});
 
-			expect(checkScopeAuthority).toBeCalledTimes(1);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "custom", scopeFn);
+			expect(scopeFn).toBeCalledTimes(1);
+			expect(scopeFn).toBeCalledWith({ tenantId: 1001, status: true, a: 5, b: "Yes" }, ctx, {
+				query: { tenantId: 1001, status: true, a: 5, b: "Yes" },
+				scope: "custom"
+			});
+
+			expect(checkScopeAuthority).toBeCalledTimes(3);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"custom",
+				scopeFn,
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
 		});
 
 		it("should add multiple scope", async () => {
@@ -184,15 +322,41 @@ describe("Test scoping", () => {
 
 			const res = await svc._applyScopes(params, ctx);
 			expect(res).toEqual({
-				query: { a: 5, b: "Yes", visibility: "public" },
+				query: { tenantId: 1001, status: true, a: 5, b: "Yes", visibility: "public" },
 				scope: ["custom", "notExist", "public"]
 			});
 
-			expect(checkScopeAuthority).toBeCalledTimes(2);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "custom", scopeFn);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", {
-				visibility: "public"
-			});
+			expect(checkScopeAuthority).toBeCalledTimes(4);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"custom",
+				scopeFn,
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"public",
+				{
+					visibility: "public"
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
 		});
 
 		it("should not add desired scope if not permission", async () => {
@@ -201,26 +365,96 @@ describe("Test scoping", () => {
 			const params = { scope: "public" };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: {}, scope: "public" });
+			expect(res).toEqual({ scope: "public" });
 
-			expect(checkScopeAuthority).toBeCalledTimes(1);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "public", {
-				visibility: "public"
-			});
+			expect(checkScopeAuthority).toBeCalledTimes(3);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"public",
+				{
+					visibility: "public"
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"add"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"add"
+			);
 		});
 
-		it("should not disable the default scope", async () => {
-			checkScopeAuthorityReturnValue = scopeName => scopeName != null;
+		it("should not disable the tenant scope", async () => {
+			checkScopeAuthorityReturnValue = scopeName => scopeName != "tenant";
 			checkScopeAuthority.mockClear();
 			const params = { scope: false };
 
 			const res = await svc._applyScopes(params, ctx);
-			expect(res).toEqual({ query: { status: true }, scope: false });
+			expect(res).toEqual({ query: { tenantId: 1001 }, scope: false });
 			expect(checkScopeAuthority).toBeCalledTimes(2);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), null, null);
-			expect(checkScopeAuthority).toBeCalledWith(expect.any(Context), "onlyActive", {
-				status: true
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"remove"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"remove"
+			);
+		});
+
+		it("should not disable the tenant scope", async () => {
+			checkScopeAuthorityReturnValue = scopeName => scopeName != "tenant";
+			checkScopeAuthority.mockClear();
+			const params = { scope: ["public", "-tenant", "-onlyActive"] };
+
+			const res = await svc._applyScopes(params, ctx);
+			expect(res).toEqual({
+				query: { tenantId: 1001, visibility: "public" },
+				scope: ["public", "-tenant", "-onlyActive"]
 			});
+			expect(checkScopeAuthority).toBeCalledTimes(3);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"onlyActive",
+				{
+					status: true
+				},
+				"remove"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"tenant",
+				{
+					tenantId: 1001
+				},
+				"remove"
+			);
+			expect(checkScopeAuthority).toBeCalledWith(
+				expect.any(Context),
+				"public",
+				{
+					visibility: "public"
+				},
+				"add"
+			);
 		});
 	});
 

--- a/test/unit/scoping.spec.js
+++ b/test/unit/scoping.spec.js
@@ -25,7 +25,10 @@ describe("Test scoping", () => {
 					public: {
 						visibility: "public"
 					},
-					custom: scopeFn
+					custom: scopeFn,
+					private: {
+						visibility: "private"
+					}
 				},
 
 				defaultScopes: ["tenant", "onlyActive"]
@@ -104,6 +107,16 @@ describe("Test scoping", () => {
 			expect(res).toEqual({
 				query: { status: true, tenantId: 1001, a: 5, b: "Yes", visibility: "public" },
 				scope: ["custom", "notExist", "public"]
+			});
+		});
+
+		it("should overwrite previos scope", async () => {
+			const params = { scope: ["public", "custom", "private"] };
+
+			const res = await svc._applyScopes(params, ctx);
+			expect(res).toEqual({
+				query: { status: true, tenantId: 1001, a: 5, b: "Yes", visibility: "private" },
+				scope: ["public", "custom", "private"]
 			});
 		});
 	});


### PR DESCRIPTION
Closes #13.

## Breaking change

**Old behaviour**
The `scope: ["onlyActive"]` disabled all default scopes and added the `onlyActive` scope.

**New behaviour**
The `scope: ["onlyActive"]` added the `onlyActive` scope besides all default scopes.

### Disabling default scopes
To disable a default scope, use the `-` (minus) sign before the scope name. E.g: `scope: ["-onlyActive", "myScope"]`

### Disabling all scopes
It's not changed. Use `scope: false`

### `checkScopeAuthority` signature changed.
The `checkScopeAuthority` method signature is changed to support the new default scope disabling logic.

```js
		/**
		 * Check the scope authority. Should be implemented in the service.
		 *
		 * @param {Context} ctx
		 * @param {String} name
		 * @param {String} operation Values: "add", "remove"
		 * @param {Object} scope
		 */
		async checkScopeAuthority(ctx, name, operation, scope) {
			return true;
		},
```

### Full example
This example demonstrates a tenant scope authorization. It disables removing tenant scope for users, but allows for administrators.

```js
module.exports = {
    name: "posts",
    mixins: [DbService()],
    settings: {
        fields: {/*...*/},

        scopes: {
            tenant(q, ctx) {
                q.tenantId = ctx.meta.tenantId;
                return q;
            },
            onlyActive: {
                status: true
            }
        },
        defaultScopes: ["tenant"]
    },

    methods: {
        async checkScopeAuthority(ctx, name, operation) {
            // Admin can add/remove any scopes
            if (ctx.meta.user.roles.includes("admin"))
                return true;

            // Disable removing tenant scope
            if (name == "tenant" && operation == "remove")
                return false;

            return true;
        }
    }
}
```