### PR TITLE
Option to reorder the resolve result

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -871,6 +871,7 @@ Resolve an entity based on one or more IDs.
 | `populate` | `String\|Array<String>` | `null` | Populated fields. |
 | `mapping` | `boolean` | `false` | Convert the result to `Object` where the key is the ID. |
 | `throwIfNotExist` | `boolean` | `false` | If `true`, the error `EntityNotFound` is thrown if the entity does not exist. |
+| `reorderResult` | `boolean` | `false` | If `true` and the ID is an array, the result will be reordered according to the order of IDs. |
 
 
 ### REST endpoint
@@ -1279,6 +1280,7 @@ Return entity(ies) by ID(s).
 | `opts` | `Object` | `{}` | Other options for internal methods. |
 | `opts.transform` | `Boolean` | `true` | If `false`, the result won't be transformed. |
 | `opts.throwIfNotExist` | `boolean` | `false` | If `true`, the error `EntityNotFound` is thrown if the entity does not exist. |
+| `opts.reorderResult` | `boolean` | `false` | If `true` and the ID is an array, the result will be reordered according to the order of IDs. |
 
 
 ## `createEntity`

--- a/src/actions.js
+++ b/src/actions.js
@@ -279,7 +279,8 @@ module.exports = function (mixinOpts) {
 				"scope",
 				"populate",
 				"mapping",
-				"throwIfNotExist"
+				"throwIfNotExist",
+				"reorderResult"
 			]),
 			params: {
 				// The "id" field get from `fields`
@@ -287,11 +288,13 @@ module.exports = function (mixinOpts) {
 				scope: PARAMS_SCOPE,
 				populate: PARAMS_POPULATE,
 				mapping: { type: "boolean", optional: true },
-				throwIfNotExist: { type: "boolean", optional: true }
+				throwIfNotExist: { type: "boolean", optional: true },
+				reorderResult: { type: "boolean", optional: true }
 			},
 			async handler(ctx) {
 				return this.resolveEntities(ctx, ctx.params, {
-					throwIfNotExist: ctx.params.throwIfNotExist
+					throwIfNotExist: ctx.params.throwIfNotExist,
+					reorderResult: ctx.params.reorderResult
 				});
 			}
 		};

--- a/src/methods.js
+++ b/src/methods.js
@@ -495,7 +495,7 @@ module.exports = function (mixinOpts) {
 				const tmp = [];
 				id.forEach(id => {
 					const idx = unTransformedRes.findIndex(doc => doc[idField] == id);
-					tmp.push(idx ? result[idx] : null);
+					tmp.push(idx != -1 ? result[idx] : null);
 				});
 				result = tmp;
 			} else if (!multi) {

--- a/src/methods.js
+++ b/src/methods.js
@@ -490,6 +490,14 @@ module.exports = function (mixinOpts) {
 					map[id] = doc;
 					return map;
 				}, {});
+			} else if (multi && opts.reorderResult) {
+				// Reorder result to the same as ID array (it needs for DataLoader)
+				const tmp = [];
+				id.forEach(id => {
+					const idx = unTransformedRes.findIndex(doc => doc[idField] == id);
+					tmp.push(idx ? result[idx] : null);
+				});
+				result = tmp;
 			} else if (!multi) {
 				result = result[0];
 			}

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -117,9 +117,9 @@ if (process.env.GITHUB_ACTIONS_CI) {
 	Adapters = [
 		{
 			type: "NeDB"
-		},
+		}
 		/*{ type: "MongoDB", options: { dbName: "db_int_test" } },*/
-		{
+		/*{
 			name: "Knex-SQLite",
 			type: "Knex",
 			options: {
@@ -137,7 +137,7 @@ if (process.env.GITHUB_ACTIONS_CI) {
 					}
 				}
 			}
-		}
+		}*/
 		/*{
 			name: "Knex-Postgresql",
 			type: "Knex",
@@ -230,15 +230,15 @@ describe("Integration tests", () => {
 		getAdapter.IdColumnType = ["Knex"].includes(adapter.type) ? "integer" : "string";
 
 		describe(`Adapter: ${adapter.name || adapter.type}`, () => {
-			describe("Test adapter", () => AdapterTests(getAdapter, adapter.type));
+			//describe("Test adapter", () => AdapterTests(getAdapter, adapter.type));
 			describe("Test methods", () => MethodTests(getAdapter, adapter.type));
-			describe("Test scopes", () => ScopeTests(getAdapter, adapter.type));
-			describe("Test actions", () => ActionsTests(getAdapter, adapter.type));
-			describe("Test transformations", () => TransformTests(getAdapter, adapter.type));
-			describe("Test populating", () => PopulateTests(getAdapter, adapter.type));
-			describe("Test Validations", () => ValidationTests(getAdapter, adapter.type));
-			describe("Test REST", () => RESTTests(getAdapter, adapter.type));
-			describe("Test Tenants", () => TenantTests(getAdapter, adapter.type));
+			// describe("Test scopes", () => ScopeTests(getAdapter, adapter.type));
+			// describe("Test actions", () => ActionsTests(getAdapter, adapter.type));
+			// describe("Test transformations", () => TransformTests(getAdapter, adapter.type));
+			// describe("Test populating", () => PopulateTests(getAdapter, adapter.type));
+			// describe("Test Validations", () => ValidationTests(getAdapter, adapter.type));
+			// describe("Test REST", () => RESTTests(getAdapter, adapter.type));
+			// describe("Test Tenants", () => TenantTests(getAdapter, adapter.type));
 		});
 	}
 });

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -230,15 +230,15 @@ describe("Integration tests", () => {
 		getAdapter.IdColumnType = ["Knex"].includes(adapter.type) ? "integer" : "string";
 
 		describe(`Adapter: ${adapter.name || adapter.type}`, () => {
-			//describe("Test adapter", () => AdapterTests(getAdapter, adapter.type));
+			describe("Test adapter", () => AdapterTests(getAdapter, adapter.type));
 			describe("Test methods", () => MethodTests(getAdapter, adapter.type));
-			// describe("Test scopes", () => ScopeTests(getAdapter, adapter.type));
-			// describe("Test actions", () => ActionsTests(getAdapter, adapter.type));
-			// describe("Test transformations", () => TransformTests(getAdapter, adapter.type));
-			// describe("Test populating", () => PopulateTests(getAdapter, adapter.type));
-			// describe("Test Validations", () => ValidationTests(getAdapter, adapter.type));
-			// describe("Test REST", () => RESTTests(getAdapter, adapter.type));
-			// describe("Test Tenants", () => TenantTests(getAdapter, adapter.type));
+			describe("Test scopes", () => ScopeTests(getAdapter, adapter.type));
+			describe("Test actions", () => ActionsTests(getAdapter, adapter.type));
+			describe("Test transformations", () => TransformTests(getAdapter, adapter.type));
+			describe("Test populating", () => PopulateTests(getAdapter, adapter.type));
+			describe("Test Validations", () => ValidationTests(getAdapter, adapter.type));
+			describe("Test REST", () => RESTTests(getAdapter, adapter.type));
+			describe("Test Tenants", () => TenantTests(getAdapter, adapter.type));
 		});
 	}
 });

--- a/test/integration/methods.test.js
+++ b/test/integration/methods.test.js
@@ -480,6 +480,54 @@ module.exports = (getAdapter, adapterType) => {
 				});
 			});
 
+			it("resolve entities by IDs with reordering", async () => {
+				const res = await svc.resolveEntities(
+					ctx,
+					{
+						id: [
+							docs.johnDoe.id,
+							docs.bobSmith.id,
+							docs.kevinJames.id,
+							null,
+							docs.janeDoe.id,
+							"123456879"
+						]
+					},
+					{ reorderResult: true }
+				);
+				expect(res).toEqual([
+					docs.johnDoe,
+					docs.bobSmith,
+					docs.kevinJames,
+					null,
+					docs.janeDoe,
+					null
+				]);
+
+				const res2 = await svc.resolveEntities(
+					ctx,
+					{
+						id: [
+							"123456879",
+							docs.janeDoe.id,
+							null,
+							docs.kevinJames.id,
+							docs.bobSmith.id,
+							docs.johnDoe.id
+						]
+					},
+					{ reorderResult: true }
+				);
+				expect(res2).toEqual([
+					null,
+					docs.janeDoe,
+					null,
+					docs.kevinJames,
+					docs.bobSmith,
+					docs.johnDoe
+				]);
+			});
+
 			it("throw Missing ID", async () => {
 				expect.assertions(4);
 				try {

--- a/test/integration/validation.test.js
+++ b/test/integration/validation.test.js
@@ -2641,7 +2641,7 @@ module.exports = (getAdapter, adapterType) => {
 		it("check 'get' action", async () => {
 			expect(svc.schema.actions.get).toEqual({
 				handler: expect.any(Function),
-				cache: { enabled: true, keys: ["key", "populate", "fields", "#userID"] },
+				cache: { enabled: true, keys: ["key", "fields", "scope", "populate", "#userID"] },
 				rest: "GET /:key",
 				visibility: "published",
 				params: {
@@ -2666,7 +2666,19 @@ module.exports = (getAdapter, adapterType) => {
 		it("check 'resolve' action", async () => {
 			expect(svc.schema.actions.resolve).toEqual({
 				handler: expect.any(Function),
-				cache: { enabled: true, keys: ["key", "populate", "fields", "mapping", "#userID"] },
+				cache: {
+					enabled: true,
+					keys: [
+						"key",
+						"fields",
+						"scope",
+						"populate",
+						"mapping",
+						"throwIfNotExist",
+						"reorderResult",
+						"#userID"
+					]
+				},
 				visibility: "published",
 				params: {
 					fields: [
@@ -2687,7 +2699,8 @@ module.exports = (getAdapter, adapterType) => {
 						{ optional: true, type: "string" },
 						{ items: "string", optional: true, type: "array" }
 					],
-					throwIfNotExist: { optional: true, type: "boolean" }
+					throwIfNotExist: { optional: true, type: "boolean" },
+					reorderResult: { optional: true, type: "boolean" }
 				}
 			});
 		});
@@ -2720,6 +2733,7 @@ module.exports = (getAdapter, adapterType) => {
 						"sort",
 						"search",
 						"searchFields",
+						"collation",
 						"scope",
 						"populate",
 						"query",
@@ -2787,6 +2801,7 @@ module.exports = (getAdapter, adapterType) => {
 						"sort",
 						"search",
 						"searchFields",
+						"collation",
 						"scope",
 						"populate",
 						"query",


### PR DESCRIPTION
New `reorderResult` option to reorder the result of `resolveEntities`. It's necessary for DataLoader