### PR TITLE
Store adapter after connect

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -35,9 +35,9 @@ module.exports = function (mixinOpts) {
 			this.logger.debug(`Adapter not found for '${hash}'. Create a new adapter instance...`);
 			const adapter = Adapters.resolve(adapterOpts);
 			adapter.init(this);
-			await this.maintenanceAdapters();
 			await this._connect(adapter, hash, adapterOpts);
 			this.adapters.set(hash, { hash, adapter, touched: Date.now() });
+			await this.maintenanceAdapters();
 			this.logger.info(
 				`Adapter '${hash}' connected. Number of adapters:`,
 				this.adapters.size

--- a/src/methods.js
+++ b/src/methods.js
@@ -35,9 +35,9 @@ module.exports = function (mixinOpts) {
 			this.logger.debug(`Adapter not found for '${hash}'. Create a new adapter instance...`);
 			const adapter = Adapters.resolve(adapterOpts);
 			adapter.init(this);
-			this.adapters.set(hash, { hash, adapter, touched: Date.now() });
 			await this.maintenanceAdapters();
 			await this._connect(adapter, hash, adapterOpts);
+			this.adapters.set(hash, { hash, adapter, touched: Date.now() });
 			this.logger.info(
 				`Adapter '${hash}' connected. Number of adapters:`,
 				this.adapters.size


### PR DESCRIPTION
Hi,
If an action is executed twice by the front end, and the time between one call and another is very short, then it is possible that the second call get an adapter that had not yet finished the connection with the database, returning an error that the adapter does not have the required method to perform the action.
Moving the statement that stores the adapter instance after the connection solves this problem.
Please, verify.

Thanks,
Roni Cruz
