### PR TITLE
fix mongodb adapter

### DIFF
--- a/src/adapters/mongodb.js
+++ b/src/adapters/mongodb.js
@@ -137,7 +137,7 @@ class MongoDBAdapter extends BaseAdapter {
 	 */
 	stringToObjectID(id) {
 		if (typeof id == "string" && ObjectId.isValid(id))
-			return new ObjectId.createFromHexString(id);
+			return ObjectId.createFromHexString(id);
 
 		return id;
 	}


### PR DESCRIPTION
Fixes TypeError: ObjectId.createFromHexString is not a constructor